### PR TITLE
Add mobile right alignment option for newsletter logo

### DIFF
--- a/blocks/comprehensive-footer.liquid
+++ b/blocks/comprehensive-footer.liquid
@@ -471,6 +471,34 @@
       gap: 8px;
     }
 
+    .ai-footer-newsletter-header-{{ ai_gen_id }}.ai-footer-newsletter-header--mobile-center {
+      align-items: center;
+      text-align: center;
+    }
+
+    .ai-footer-newsletter-header-{{ ai_gen_id }}.ai-footer-newsletter-header--mobile-center .ai-footer-newsletter-copy-{{ ai_gen_id }} {
+      text-align: center;
+    }
+
+    .ai-footer-newsletter-header-{{ ai_gen_id }}.ai-footer-newsletter-header--mobile-center .ai-footer-newsletter-logo-{{ ai_gen_id }},
+    .ai-footer-newsletter-header-{{ ai_gen_id }}.ai-footer-newsletter-header--mobile-center .ai-footer-newsletter-logo-placeholder-{{ ai_gen_id }} {
+      margin: 0 auto;
+    }
+
+    .ai-footer-newsletter-header-{{ ai_gen_id }}.ai-footer-newsletter-header--mobile-right {
+      align-items: flex-end;
+      text-align: right;
+    }
+
+    .ai-footer-newsletter-header-{{ ai_gen_id }}.ai-footer-newsletter-header--mobile-right .ai-footer-newsletter-copy-{{ ai_gen_id }} {
+      text-align: right;
+    }
+
+    .ai-footer-newsletter-header-{{ ai_gen_id }}.ai-footer-newsletter-header--mobile-right .ai-footer-newsletter-logo-{{ ai_gen_id }},
+    .ai-footer-newsletter-header-{{ ai_gen_id }}.ai-footer-newsletter-header--mobile-right .ai-footer-newsletter-logo-placeholder-{{ ai_gen_id }} {
+      margin-left: auto;
+    }
+
     .ai-footer-left-section-{{ ai_gen_id }},
     .ai-footer-right-section-{{ ai_gen_id }} {
       padding: 20px;
@@ -514,7 +542,15 @@
       <div class="ai-footer-left-section-{{ ai_gen_id }}">
         {% if block.settings.show_newsletter %}
           <div class="ai-footer-newsletter-{{ ai_gen_id }}">
-            <div class="ai-footer-newsletter-header-{{ ai_gen_id }}">
+            {% assign mobile_alignment_class = '' %}
+            {% case block.settings.newsletter_logo_mobile_alignment %}
+              {% when 'center' %}
+                {% assign mobile_alignment_class = ' ai-footer-newsletter-header--mobile-center' %}
+              {% when 'right' %}
+                {% assign mobile_alignment_class = ' ai-footer-newsletter-header--mobile-right' %}
+            {% endcase %}
+
+            <div class="ai-footer-newsletter-header-{{ ai_gen_id }}{{ mobile_alignment_class }}">
               {% if block.settings.newsletter_logo %}
                 <img
                   src="{{ block.settings.newsletter_logo | image_url: width: 200}}"
@@ -737,6 +773,27 @@
       "unit": "px",
       "label": "Newsletter logo size",
       "default": 120
+    },
+    {
+      "type": "select",
+      "id": "newsletter_logo_mobile_alignment",
+      "label": "Mobile newsletter logo alignment",
+      "info": "Controls the placement of the newsletter logo and copy on screens smaller than 750px.",
+      "options": [
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "center",
+          "label": "Center"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ],
+      "default": "left"
     },
     {
       "type": "text",


### PR DESCRIPTION
## Summary
- add a theme editor select setting to control the newsletter logo alignment on mobile devices (left, center, or right)
- update the mobile stylesheet to handle centered and right-aligned newsletter headers when selected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab575f96883288c23d93a7a5f3cea